### PR TITLE
Increase restart times and add latency wait

### DIFF
--- a/condor_submit/profile/config.yaml
+++ b/condor_submit/profile/config.yaml
@@ -15,8 +15,9 @@ singularity-args: "--cleanenv -B $HOME/Software -B $HOME/muraves_outputs -B /tmp
 max-jobs-per-second: 100
 max-status-checks-per-second: 1
 seconds-between-status-checks: 120
-restart-times: 0
+restart-times: 2
 local-cores: 1
 jobs: 250
 cores: {threads}
+latency-wait: 60
 verbose: False


### PR DESCRIPTION
Increased Snakemake latency-wait from default to 60 seconds to account for filesystem latency in the Condor environment. Jobs were occasionally completing without their expected temporary/output files being immediately visible locally, causing Snakemake to report missing files after the initial wait period.

Also increased restart-times to 2 so that jobs encountering transient failures are automatically retried up to two times.